### PR TITLE
add replicasets.apps to ClusterRole to avoid permission issue

### DIFF
--- a/deploy/kubernetes/metricbeat-kubernetes.yaml
+++ b/deploy/kubernetes/metricbeat-kubernetes.yaml
@@ -324,6 +324,7 @@ rules:
 - apiGroups: ["apps"]
   resources:
   - statefulsets
+  - replicasets
   - deployments
   verbs: ["get", "list", "watch"]
 - apiGroups:


### PR DESCRIPTION
Error message:
E0120 09:24:12.769663       1 reflector.go:125] github.com/elastic/beats/libbeat/common/kubernetes/watcher.go:235: Failed to list *v1beta1.ReplicaSet: replicasets.apps is forbidden: User "system:serviceaccount:kube-system:metricbeat" cannot list resource "replicasets" in API group "apps" at the cluster scope

Fixed after add the permission